### PR TITLE
Updates to verify document is in session before download

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ const args = {
   // string to specifiy auth token cookie, default: '__auth-token' *optional*
   authorizationTokenCookieName: '__auth-token',
   // string to specify the service to fetch the documents from *required*
-  documentServiceUrl: 'service-url'
+  documentServiceUrl: 'service-url',
+  // array to paths where file collections are stored *required*
+  // this is used to get the file id from the session given the file name. all downloadable
+  // files must be included in these paths
+  sessionFileCollectionsPaths: ['case.data.d8', 'files']
 };
 initDocumentHandler(app, middleware, args);
 ```

--- a/config.js
+++ b/config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  defaultArgs: { uri: '/document-download/:documentId' },
+  defaultArgs: {
+    uri: '/document-download/:documentName',
+    documentNamePath: 'value.DocumentFileName'
+  },
   documentHandlerDefaultArgs: { authorizationTokenCookieName: '__auth-token' },
-  createUrisDefaultArgs: { fileNamePath: 'value.DocumentFileName' }
+  createUrisDefaultArgs: {}
 };

--- a/lib/createUris.js
+++ b/lib/createUris.js
@@ -11,14 +11,14 @@ const createUris = (files = [], args = {}) => {
   );
 
   return files.map(file => {
-    const fileName = get(file, createUriOptions.fileNamePath);
-    if (!fileName) {
+    const documentName = get(file, createUriOptions.documentNamePath);
+    if (!documentName) {
       throw new Error(`No file name found for file: ${JSON.stringify(file)}`);
     }
 
-    const parsed = parse(fileName);
+    const parsed = parse(documentName);
     return {
-      uri: createUriOptions.uri.replace(':documentId', file.id),
+      uri: createUriOptions.uri.replace(':documentName', documentName),
       type: parsed.name.replace(/[^a-z]/gi, ''),
       fileType: parsed.ext.replace('.', '')
     };

--- a/lib/initDocumentHandler.js
+++ b/lib/initDocumentHandler.js
@@ -9,8 +9,12 @@ const initDocumentHandler = (app = {}, middlware = [], args = {}) => {
     args
   );
 
-  if (!documentHandlerOptions.uri || !documentHandlerOptions.uri.includes(':documentId')) {
-    throw new Error('Document handler uri must include `:documentId` param');
+  if (!documentHandlerOptions.uri || !documentHandlerOptions.uri.includes(':documentName')) {
+    throw new Error('Document handler uri must include `:documentName` param');
+  }
+
+  if (!documentHandlerOptions.sessionFileCollectionsPaths || !documentHandlerOptions.sessionFileCollectionsPaths.length) {
+    throw new Error('Document handler sessionFileCollectionsPaths must be included in configuration');
   }
 
   if (!app.use) {

--- a/lib/middleware/documentHandlerMiddleware.js
+++ b/lib/middleware/documentHandlerMiddleware.js
@@ -1,4 +1,5 @@
 const request = require('request');
+const { get } = require('lodash');
 
 const documentHandler = (options = {}) => {
   if (!options.documentServiceUrl) {
@@ -6,13 +7,30 @@ const documentHandler = (options = {}) => {
   }
 
   return (req, res, next) => {
-    const documentId = req.params.documentId;
+    const documentName = req.params.documentName;
     const token = req.cookies[options.authorizationTokenCookieName];
 
-    const path = `${options.documentServiceUrl}/${documentId}`;
+    // collect all downloadable files
+    const files = options.sessionFileCollectionsPaths
+      .reduce((allFiles, path) => {
+        const filesInSession = get(req.session, path) || [];
+        return [...allFiles, ...filesInSession];
+      }, []);
+
+    const file = files.find(f => {
+      const fileName = get(f, options.documentNamePath);
+      return fileName === documentName;
+    });
+
+    // if no document Id found let the request fall through and be captured by OPP for 404
+    if (!file) {
+      return next();
+    }
+
+    const path = `${options.documentServiceUrl}/${file.id}`;
     const headers = { Authorization: `Bearer ${token}` };
 
-    request
+    return request
       .get(path, { headers })
       .on('error', next)
       .pipe(res);

--- a/test/lib/createUris.test.js
+++ b/test/lib/createUris.test.js
@@ -7,8 +7,9 @@ const THREE = 3;
 describe('lib/createUris', () => {
   describe('type and url', () => {
     let results = {};
+    let files = [];
     before(() => {
-      const files = [
+      files = [
         {
           id: 'id1',
           value: { DocumentFileName: 'filename1234567890.pdf' }
@@ -40,7 +41,7 @@ describe('lib/createUris', () => {
 
     it('creates a url to access file', () => {
       results.forEach((result, index) => {
-        const uri = config.defaultArgs.uri.replace(':documentId', `id${index + 1}`);
+        const uri = config.defaultArgs.uri.replace(':documentName', `${files[index].value.DocumentFileName}`);
         expect(result.uri).to.eql(uri);
       });
     });
@@ -61,21 +62,24 @@ describe('lib/createUris', () => {
       }
     ];
     const args = {
-      fileNamePath: 'name',
-      uri: '/a/different/path/to/file/:documentId'
+      documentNamePath: 'name',
+      uri: '/a/different/path/to/file/:documentName'
     };
 
-    before(() => {
-      results = createUris(files, args);
-    });
-
     it('used custom uri to generate file uri', () => {
-      const uri = args.uri.replace(':documentId', 'id1');
+      results = createUris(files, args);
+      const uri = args.uri.replace(':documentName', `${files[0].name}`);
       expect(results[0].uri).to.eql(uri);
     });
 
-    it('used custom fileNamePath to get filename', () => {
+    it('used custom documentNamePath to get filename', () => {
+      results = createUris(files, args);
       expect(results[0].type).to.eql('filename');
+    });
+
+    it('handles when no files or arguments parsed', () => {
+      results = createUris();
+      expect(results.length).to.eql(0);
     });
   });
 

--- a/test/lib/middleware/documentHandlerMiddleware.test.js
+++ b/test/lib/middleware/documentHandlerMiddleware.test.js
@@ -2,6 +2,7 @@ const documentHandlerMiddleware = require('../../../lib/middleware/documentHandl
 const sinon = require('sinon');
 const request = require('request');
 const { expect } = require('../../chai');
+const config = require('../../../config');
 
 describe('lib/middleware/documentHandlerMiddleware', () => {
   let pipe = {};
@@ -11,7 +12,6 @@ describe('lib/middleware/documentHandlerMiddleware', () => {
     pipe = sinon.stub();
     get = { pipe };
     get.on = sinon.stub().returns(get);
-
     sinon.stub(request, 'get').returns(get);
   });
 
@@ -21,12 +21,32 @@ describe('lib/middleware/documentHandlerMiddleware', () => {
 
   describe('execute request', () => {
     const req = {
-      params: { documentId: '123' },
-      cookies: { '__auth-token': 'some-token' }
+      params: { documentName: 'file-1' },
+      cookies: { '__auth-token': 'some-token' },
+      session: {
+        files: [
+          {
+            id: '401ab79e-34cb-4570-9f2f-4cf9357dc1ec',
+            value: { DocumentFileName: 'file-1' }
+          },
+          {
+            id: '401ab79e-34cb-4570-9f2f-gsd7452sg211',
+            value: { DocumentFileName: 'file-2' }
+          }
+        ]
+      }
     };
     const res = sinon.stub();
 
-    const options = { documentServiceUrl: 'http://localhost9000' };
+    const options = Object.assign(
+      {},
+      config.documentHandlerDefaultArgs,
+      config.defaultArgs,
+      {
+        documentServiceUrl: 'http://localhost9000',
+        sessionFileCollectionsPaths: ['files']
+      }
+    );
 
     before(() => {
       const handler = documentHandlerMiddleware(options);
@@ -42,22 +62,86 @@ describe('lib/middleware/documentHandlerMiddleware', () => {
     });
 
     it('uses the correct url', () => {
-      const path = `${options.documentServiceUrl}/${req.params.documentId}`;
-      expect(request.get).calledWith(path, sinon.match.any);
+      const path = `${options.documentServiceUrl}/${req.session.files[0].id}`;
+      expect(request.get).calledWith(path);
+    });
+  });
+
+  describe('find files in multiple locations', () => {
+    const req = {
+      params: { documentName: 'file-1' },
+      cookies: { '__auth-token': 'some-token' },
+      session: {
+        files: [
+          {
+            id: '401ab79e-34cb-4570-9f2f-4cf9357dc1ec',
+            value: { DocumentFileName: 'file-1' }
+          }
+        ],
+        case: {
+          files: [
+            {
+              id: '401ab79e-34cb-4570-9f2f-asgasg6532',
+              value: { DocumentFileName: 'file-2' }
+            }
+          ]
+        }
+      }
+    };
+    const res = sinon.stub();
+
+    const options = Object.assign(
+      {},
+      config.documentHandlerDefaultArgs,
+      config.defaultArgs,
+      {
+        documentServiceUrl: 'http://localhost9000',
+        sessionFileCollectionsPaths: ['files', 'case.files']
+      }
+    );
+
+    const handler = documentHandlerMiddleware(options);
+
+    it('file-1', () => {
+      req.params.documentName = 'file-1';
+      handler(req, res);
+      const path = `${options.documentServiceUrl}/${req.session.files[0].id}`;
+      expect(request.get).calledWith(path);
+    });
+
+    it('file-2', () => {
+      req.params.documentName = 'file-2';
+      handler(req, res);
+      const path = `${options.documentServiceUrl}/${req.session.case.files[0].id}`;
+      expect(request.get).calledWith(path);
     });
   });
 
   describe('config', () => {
     const req = {
-      params: { documentId: '123' },
-      cookies: { '__custom-token-name': 'some-token' }
+      params: { documentName: 'file-1' },
+      cookies: { '__custom-token-name': 'some-token' },
+      session: {
+        files: [
+          {
+            id: '401ab79e-34cb-4570-9f2f-4cf9357dc1ec',
+            value: { DocumentFileName: 'file-1' }
+          }
+        ]
+      }
     };
     const res = sinon.stub();
 
-    const options = {
-      authorizationTokenCookieName: '__custom-token-name',
-      documentServiceUrl: 'http://localhost9000'
-    };
+    const options = Object.assign(
+      {},
+      config.documentHandlerDefaultArgs,
+      config.defaultArgs,
+      {
+        authorizationTokenCookieName: '__custom-token-name',
+        documentServiceUrl: 'http://localhost9000',
+        sessionFileCollectionsPaths: ['files']
+      }
+    );
 
     before(() => {
       const handler = documentHandlerMiddleware(options);
@@ -86,18 +170,61 @@ describe('lib/middleware/documentHandlerMiddleware', () => {
 
     it('parses error to next if request fails', () => {
       const req = {
-        params: { documentId: '123' },
-        cookies: { '__auth-token': 'some-token' }
+        params: { documentName: 'file-1' },
+        cookies: { '__auth-token': 'some-token' },
+        session: {
+          files: [
+            {
+              id: '401ab79e-34cb-4570-9f2f-4cf9357dc1ec',
+              value: { DocumentFileName: 'file-1' }
+            }
+          ]
+        }
       };
       const res = sinon.stub();
       const next = sinon.stub();
 
-      const options = { documentServiceUrl: 'http://localhost9000' };
+      const options = Object.assign(
+        {},
+        config.documentHandlerDefaultArgs,
+        config.defaultArgs,
+        {
+          authorizationTokenCookieName: '__custom-token-name',
+          documentServiceUrl: 'http://localhost9000',
+          sessionFileCollectionsPaths: ['files']
+        }
+      );
       const handler = documentHandlerMiddleware(options);
 
       handler(req, res, next);
 
       expect(get.on.calledWith('error', next)).to.eql(true);
+    });
+
+    it('if file not found calls next', () => {
+      const req = {
+        params: { documentName: 'file-2' },
+        cookies: { '__auth-token': 'some-token' },
+        session: {}
+      };
+      const res = sinon.stub();
+      const next = sinon.stub();
+
+      const options = Object.assign(
+        {},
+        config.documentHandlerDefaultArgs,
+        config.defaultArgs,
+        {
+          authorizationTokenCookieName: '__custom-token-name',
+          documentServiceUrl: 'http://localhost9000',
+          sessionFileCollectionsPaths: ['files']
+        }
+      );
+      const handler = documentHandlerMiddleware(options);
+
+      handler(req, res, next);
+
+      expect(next.calledOnce).to.eql(true);
     });
   });
 });


### PR DESCRIPTION
[DIV-4682 - update document handler to validate the file the user downloading is theirs](https://tools.hmcts.net/jira/browse/DIV-4682)
- Dont expose document id to client
- Find document id by searching session for document name
- Additional setup option to configure where files can be found in session